### PR TITLE
feat: allow using the `to-human-readable` passing an array of path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 data-*/
-paths-data-*/
+paths-*/
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -43,7 +43,12 @@ $ ./asmapy.py download 20220202
 After downloading the dumps, they will be available in a folder (e.g. `data-20220202`), and you can use that directory in the following command to convert them to a human-readable format:
 
 ```sh
-$ ./asmapy.py to-human-readable data-20220202 --singleoutput
+$ ./asmapy.py to-human-readable -p data-20220202
+```
+
+You can also pass more than one folder, this can be useful to combine data from different dates, e.g:
+```sh
+$ ./asmapy.py to-human-readable -p data-20220202 data-20221212
 ```
 
 Use `--allasn` to fetch all ASN for every prefix instead of unique originating one.

--- a/asmapy.py
+++ b/asmapy.py
@@ -29,7 +29,7 @@ def main():
     parser_download = subparsers.add_parser("download", help="download dumps")
     parser_download.add_argument('date', help="date to fetch dumps (format: YYYYMMDD)", type=valid_date)
     parser_convert = subparsers.add_parser("to-human-readable", help="convert dump files to human-readable dumps (getting unique originating ASN for this prefix)")
-    parser_convert.add_argument('path', help="path with files to be converted")
+    parser_convert.add_argument('-p', '--paths', nargs='+', default=[], help="paths with files to be converted", dest="paths")
     parser_convert.add_argument('-a', '--allasn', dest="all_asn",
                                  help="fetch all ASN for every prefix instead of unique originating ones", default=False, action="store_true")
     parser_convert.add_argument('-so', '--singleoutput', dest="single_output",
@@ -43,7 +43,7 @@ def main():
     if args.subcommand is None:
         parser.print_help()
     elif args.subcommand == "to-human-readable":
-        parse(args.path, args.all_asn, args.single_output)
+        parse(args.paths, args.all_asn, args.single_output)
     elif args.subcommand == "to-mapping":
         bottleneck(args.path)
     elif args.subcommand == "to-binary":

--- a/utils/parse.py
+++ b/utils/parse.py
@@ -4,43 +4,45 @@ import os
 from bgpdumpy import BGPDump, TableDumpV2
 
 
-def parse(dir, all_asn=False, single_output=True):
+def parse(dirs=[], all_asn=False, single_output=True):
     routes = []
-    for entry_file in os.scandir(dir):
-        if entry_file.is_file():
-            with BGPDump(entry_file.path) as bgp:
-                print(f"Processing {entry_file.name}...")
-                for entry in bgp:
-                    if not isinstance(entry.body, TableDumpV2):
-                        continue
+    for dir in dirs:
+        for entry_file in os.scandir(dir):
+            if entry_file.is_file():
+                with BGPDump(entry_file.path) as bgp:
+                    print(f"Processing {entry_file.name}...")
+                    for entry in bgp:
+                        if not isinstance(entry.body, TableDumpV2):
+                            continue
 
-                    prefix = '%s/%d' % (entry.body.prefix, entry.body.prefixLength)
-                    if not all_asn:
-                        list_ASN = set([
-                            route.attr.asPath.split()[-1]
-                            for route
-                            in entry.body.routeEntries])
+                        prefix = '%s/%d' % (entry.body.prefix, entry.body.prefixLength)
+                        if not all_asn:
+                            list_ASN = set([
+                                route.attr.asPath.split()[-1]
+                                for route
+                                in entry.body.routeEntries])
 
-                        for item in list(list_ASN):
-                            routes.append(f'{prefix} AS{item}\n')
-                    else:
-                        list_ASN = set([
-                            route.attr.asPath
-                            for route
-                            in entry.body.routeEntries])
-                        
-                        for item in list(list_ASN):
-                            routes.append(f'{prefix}|{item}\n')
-                
-                if not single_output:
-                    if not os.path.exists(f"paths-{dir}"):
-                        os.mkdir(f"paths-{dir}")
-                    with open(f'paths-{dir}/{entry_file.name}', 'w') as w_file:
-                        w_file.writelines(routes)
-                        routes = []
+                            for item in list(list_ASN):
+                                routes.append(f'{prefix} AS{item}\n')
+                        else:
+                            list_ASN = set([
+                                route.attr.asPath
+                                for route
+                                in entry.body.routeEntries])
+
+                            for item in list(list_ASN):
+                                routes.append(f'{prefix}|{item}\n')
+
+                    if not single_output:
+                        if not os.path.exists(f"paths-{dir}"):
+                            os.mkdir(f"paths-{dir}")
+                        with open(f'paths-{dir}/{entry_file.name}', 'w') as w_file:
+                            w_file.writelines(routes)
+                            routes = []
 
     if single_output:
-        if not os.path.exists(f"paths-{dir}"):
-            os.mkdir(f"paths-{dir}")
-        with open(f'paths-{dir}/routes.txt', 'w') as w_file:
+        final_path = '-'.join(str(d) for d in dirs)
+        if not os.path.exists(f"paths-{final_path}"):
+            os.mkdir(f"paths-{final_path}")
+        with open(f'paths-{final_path}/routes.txt', 'w') as w_file:
             w_file.writelines(routes)


### PR DESCRIPTION
Since we can download dumps from different dates using `download` command, it would be useful if we could combine them by converting them to a human readable format together, and then, we could use `to-mapping` to convert them into a text file with iprange->asn mappings.

