### PR TITLE
allow passing a list of IPs to check what ASNs related to that IPs has changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,4 @@ $ ./asmapy.py diff path/to/file1 path/to/file2
 Optional flags:
 - `--ignore-unassigned` to ignore unassigned ranges in the first input (useful when second input is filled).
 - `--unified` to get output diff in `unified` format.
+- `-ips=` Path to file with ips. It will print the ASNs related to that ips which has changed

--- a/asmapy.py
+++ b/asmapy.py
@@ -26,6 +26,7 @@ def main():
                              help="first file to compare (text or binary)")
     parser_diff.add_argument('infile2', type=argparse.FileType('rb'),
                              help="second file to compare (text or binary)")
+    parser_diff.add_argument('--ips', default="", help="Path to file with ips. It will print the ASNs related to that ips which has changed", dest="ips_path")
     parser_download = subparsers.add_parser("download", help="download dumps")
     parser_download.add_argument('date', help="date to fetch dumps (format: YYYYMMDD)", type=valid_date)
     parser_convert = subparsers.add_parser("to-human-readable", help="convert dump files to human-readable dumps (getting unique originating ASN for this prefix)")
@@ -49,7 +50,11 @@ def main():
     elif args.subcommand == "to-binary":
         convert_to_binary(args.path)
     elif args.subcommand == "diff":
-        diff(args.infile1, args.infile2, args.ignore_unassigned)
+        if args.ips_path:
+            with open(args.ips_path) as f:
+                diff(args.infile1, args.infile2, args.ignore_unassigned, f.read().splitlines())
+        else:
+            diff(args.infile1, args.infile2, args.ignore_unassigned)
     elif args.subcommand == "download":
         construct(args.date)
     else:

--- a/utils/diff.py
+++ b/utils/diff.py
@@ -1,14 +1,33 @@
 import ipaddress
 import math
+import re 
+
 from utils.file import load_file
 from utils.asmap import prefix_to_net
 
 
-def diff(infile1, infile2, ignore_unassigned=False):
+def remove_port(ips=[]):
+    ips_without_port = []
+    for ip in ips:
+        # Remove port from ip
+        re_for_ip = re.match(r'(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})', ip)
+        if re_for_ip:
+            ip = re_for_ip[0]
+        if ']' in ip:
+            ip = ip.split(']:', 1)[0]
+            ip = ip.replace('[', '')
+        ips_without_port.append(ip)
+    return ips_without_port
+
+
+def diff(infile1, infile2, ignore_unassigned=False, ips=[]):
+    if len(ips) > 0:
+        ips = remove_port(ips)
     state1 = load_file(infile1)
     state2 = load_file(infile2)
     ipv4_changed = 0
     ipv6_changed = 0
+    old_asn_changed = []
     for prefix, old_asn, new_asn in state1.diff(state2):
         if ignore_unassigned and old_asn == 0:
             continue
@@ -22,7 +41,23 @@ def diff(infile1, infile2, ignore_unassigned=False):
         elif old_asn == 0:
             print("%s AS%i # was unassigned" % (net, new_asn))
         else:
-            print("%s AS%i # was AS%i" % (net, new_asn, old_asn))
+            if len(ips) > 0:
+                if old_asn not in old_asn_changed:
+                    old_asn_changed.append(old_asn)
+                    for ip in ips:
+                        ip_type = "IPv4" if type(ipaddress.ip_address(ip)) is ipaddress.IPv4Address else "IPv6"
+                        network_type = "IPv4" if type(ipaddress.ip_network(net)) is ipaddress.IPv4Network else "IPv6"
+                        if ip_type == "IPv4" and network_type == "IPv4":
+                            if ipaddress.IPv4Address(ip) in ipaddress.IPv4Network(net):
+                                print(f"{old_asn} -> {new_asn}")
+                                break
+                        elif ip_type == "IPv6" and network_type == "IPv6":
+                            if ipaddress.IPv6Address(ip) in ipaddress.IPv6Network(net):
+                                print(f"{old_asn} -> {new_asn}")
+                                break
+
+            else:
+                print("%s AS%i # was AS%i" % (net, new_asn, old_asn))
     print(
             "# %i%s IPv4 addresses changed; %i%s IPv6 addresses changed"
             % (


### PR DESCRIPTION
This PR changes `diff` command (adding a flag `-ips`) to accept a path to a file with a list of IPs.

```diff
$ ./asmapy.py diff path/to/file1 path/to/file2 -ips=ips.txt
```

When using this flag, this command will return only the ASNs that have changed related to that IPs.